### PR TITLE
.github: add package only PAT token and update ops.yaml

### DIFF
--- a/.github/workflows/ops.yml
+++ b/.github/workflows/ops.yml
@@ -20,15 +20,13 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: pull busybox latest
-        run: docker pull docker.io/library/busybox:latest
+        run: sudo ctr image pull --all-platforms docker.io/library/busybox:latest
 
       - name: push image
         run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-
-          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
           VERSION=latest
 
-          docker tag docker.io/library/busybox:latest $IMAGE_ID:$VERSION
-          docker push $IMAGE_ID:$VERSION
+          sudo ctr image tag docker.io/library/busybox:latest $IMAGE_ID:$VERSION
+          sudo ctr image push -u ${{ github.repository_owner }}:${{ secrets.ACTION_ONLY_PACKAGE_TOKEN }} $IMAGE_ID:$VERSION


### PR DESCRIPTION
```
Note: By default, when you select the write:packages scope for your personal
access token (PAT) in the user interface, the repo scope will also be selected.
The repo scope offers unnecessary and broad access, which we recommend you
avoid using for GitHub Actions workflows in particular. For more information,
see "Security hardening for GitHub Actions." As a workaround, you can select
just the write:packages scope for your PAT in the user interface with this url:
https://github.com/settings/tokens/new?scopes=write:packages.
```

References: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry#authenticating-to-the-container-registry

Signed-off-by: Wei Fu <fuweid89@gmail.com>
